### PR TITLE
Fix #9. Variables related to term I are not being updated when using setPID

### DIFF
--- a/MiniPID.cpp
+++ b/MiniPID.cpp
@@ -111,13 +111,16 @@ void MiniPID::setF(double f){
  * @param d Derivative gain. Responds quickly to large changes in error. Small values prevents P and I terms from causing overshoot.
  */
 void MiniPID::setPID(double p, double i, double d){
-	P=p;I=i;D=d;
-	checkSigns();
+    setP(p);
+    setI(i);
+    setD(d);
 }
 
 void MiniPID::setPID(double p, double i, double d,double f){
-	P=p;I=i;D=d;F=f;
-	checkSigns();
+    setP(p);
+    setI(i);
+    setD(d);
+    setF(f);
 }
 
 /**Set the maximum output value contributed by the I component of the system


### PR DESCRIPTION
When using the setPID () method, the errorSum and maxError variables are not being updated.

This can cause problems in a situation like

```
m_pid = new MiniPID (10, 0, 0); // I = 0
m_pid-> setOutputLimits (-100, 100); // maxError = 0, maxIOutput = 200
m_pid-> setPID (10,10,10); // maxError continues 0
```

the output of term I will always be 0 due to the following line

```
Ioutput=I*errorSum;

.....

else if (maxIOutput! = 0) {
        errorSum = clamp (errorSum + error, -maxError, maxError);
}
```